### PR TITLE
Change order of response header in query string

### DIFF
--- a/lib/nagios_mklivestatus/request.rb
+++ b/lib/nagios_mklivestatus/request.rb
@@ -127,6 +127,9 @@ class Nagios::MkLiveStatus::Request
         strQuery << "\n"
       end
       
+      #get error message if some are given
+      strQuery << "ResponseHeader: fixed16\n"
+      
       #set user if needed
       if user != nil and not user.empty? and strQuery.match(/^GET\s+(hosts|hostgroups|services|servicegroup|log)\s*$/)
         strQuery << "AuthUser: #{user}\n"
@@ -157,10 +160,7 @@ class Nagios::MkLiveStatus::Request
         logger.info(line)
       end
       logger.info("---")
-      
-      #get error message if some are given
-      strQuery << "ResponseHeader: fixed16\n"
-      
+            
       socket = open_socket()
       
       logger.debug("querying ...")


### PR DESCRIPTION
If you supply ResponseHeader after OutputFormat, mklivestatus gets upset and throws back an error. This fix works around the problem by placing ResponseHeader close to the top of the query instead of at the end. 
